### PR TITLE
Include example functionality by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
 		</style>
 		
 		<script type="text/javascript" src="scripts/polyfills.js"></script>
+		<script type="text/javascript" src="scripts/example_functionality.js"></script>
 		<script type="text/javascript">
 			const MESSAGE_SHOW_TIME = 5000;
 			var message,


### PR DESCRIPTION
I'm not sure if this line was left out intentionally, but it might make it easier to demo otherwise?